### PR TITLE
using name service and adding from and receiver to liquidity methods

### DIFF
--- a/assembly/libraries/Lib.ts
+++ b/assembly/libraries/Lib.ts
@@ -1,10 +1,10 @@
 import { Base58, System, value, u128, SafeMath, Protobuf } from "@koinos/sdk-as";
 
 export class SortTokens {
-  token0: Uint8Array;
-  token1: Uint8Array;
+  token0: string;
+  token1: string;
 
-  constructor(token0: Uint8Array, token1: Uint8Array) {
+  constructor(token0: string, token1: string) {
     this.token0 = token0;
     this.token1 = token1;
   }
@@ -12,28 +12,12 @@ export class SortTokens {
 
 
 export class Lib {
-  static getCaller(): Uint8Array {
+  static getCaller(from: Uint8Array): Uint8Array {
     const caller = System.getCaller();
     if(caller.caller.length) {
       return caller.caller as Uint8Array;
     }
-    const txFieldPayee = System.getTransactionField('header.payee');
-    if(txFieldPayee) {
-      if(txFieldPayee.bytes_value.length) {
-        return txFieldPayee.bytes_value as Uint8Array;
-      }
-    }
-    const txFieldPayer = System.getTransactionField('header.payer') as value.value_type;
-    return txFieldPayer.bytes_value as Uint8Array;
-  }
-
-  static stringPathsToByte(paths: string[]): Uint8Array[] {
-    let res: Uint8Array[] = [];
-    for (let index = 0; index < paths.length; index++) {
-      let path = paths[index];
-      res.push( Base58.decode(path) );
-    }
-    return res;
+    return from;
   }
 
   static arrayToUint8Array(a: Array<u8>): Uint8Array {
@@ -43,8 +27,8 @@ export class Lib {
     return uArray;
   }
 
-  static sortTokens(tokenA: Uint8Array, tokenB: Uint8Array): SortTokens {
-    if(Base58.encode(tokenA) > Base58.encode(tokenB)) {
+  static sortTokens(tokenA: string, tokenB: string): SortTokens {
+    if(tokenA > tokenB) {
       return new SortTokens(tokenA, tokenB);
     } else {
       return new SortTokens(tokenB, tokenA);

--- a/assembly/libraries/V2Core.ts
+++ b/assembly/libraries/V2Core.ts
@@ -41,7 +41,7 @@ export class Core {
     const res = Protobuf.decode<v2core.burn_result>(callRes.res.object as Uint8Array, v2core.burn_result.decode);
     return res;
   }
-  initialize(token_a: Uint8Array, token_b: Uint8Array): boolean {
+  initialize(token_a: v2core.token_object, token_b: v2core.token_object): boolean {
     const args = new v2core.initialize_arguments(token_a, token_b);
     const callRes = System.call(this._contractId, entries.initialize_entry, Protobuf.encode(args, v2core.initialize_arguments.encode));
     return callRes.code == error.error_code.success;

--- a/assembly/proto/periphery.proto
+++ b/assembly/proto/periphery.proto
@@ -31,8 +31,8 @@ message configs_object {
 * Keys
 */
 message pair_key {
-  bytes token_a = 1;
-  bytes token_b = 2;
+  string token_a = 1;
+  string token_b = 2;
 }
 
 /*
@@ -62,27 +62,29 @@ message set_config_arguments  {
 // @read-only true
 // @result address
 message get_pair_arguments  {
-  bytes token_a  = 1 [(koinos.btype) = ADDRESS];
-  bytes token_b  = 2 [(koinos.btype) = ADDRESS];
+  string token_a  = 1;
+  string token_b  = 2;
 }
 
 // @description Create pair if it doesn't exist
 // @read-only false
 // @result empty_object
 message create_pair_arguments {
-  bytes token_a = 1 [(koinos.btype) = ADDRESS];
-  bytes token_b = 2 [(koinos.btype) = ADDRESS];
+  string token_a = 1;
+  string token_b = 2;
 }
 
 // @description Add liquidity to pair
 // @read-only false
 message add_liquidity_arguments {
-  bytes token_a = 1 [(koinos.btype) = ADDRESS];
-  bytes token_b = 2 [(koinos.btype) = ADDRESS];
-  uint64 amount_a_desired = 3 [jstype = JS_STRING];
-  uint64 amount_b_desired = 4 [jstype = JS_STRING];
-  uint64 amount_a_min = 5 [jstype = JS_STRING];
-  uint64 amount_b_min = 6 [jstype = JS_STRING];
+  bytes from = 1 [(koinos.btype) = ADDRESS];
+  bytes receiver = 2 [(koinos.btype) = ADDRESS];
+  string token_a = 3;
+  string token_b = 4;
+  uint64 amount_a_desired = 5 [jstype = JS_STRING];
+  uint64 amount_b_desired = 6 [jstype = JS_STRING];
+  uint64 amount_a_min = 7 [jstype = JS_STRING];
+  uint64 amount_b_min = 8 [jstype = JS_STRING];
 }
 message add_liquidity_result {
   uint64 liquidity = 1 [jstype = JS_STRING];
@@ -93,11 +95,13 @@ message add_liquidity_result {
 // @description Remove liquidity from pair
 // @read-only false
 message remove_liquidity_arguments {
-  bytes token_a = 1 [(koinos.btype) = ADDRESS];
-  bytes token_b = 2 [(koinos.btype) = ADDRESS];
-  uint64 liquidity = 3 [jstype = JS_STRING];
-  uint64 amount_a_min = 4 [jstype = JS_STRING];
-  uint64 amount_b_min = 5 [jstype = JS_STRING];
+  bytes from = 1 [(koinos.btype) = ADDRESS];
+  bytes receiver = 2 [(koinos.btype) = ADDRESS];
+  string token_a = 3;
+  string token_b = 4;
+  uint64 liquidity = 5 [jstype = JS_STRING];
+  uint64 amount_a_min = 6 [jstype = JS_STRING];
+  uint64 amount_b_min = 7 [jstype = JS_STRING];
 }
 message remove_liquidity_result {
   uint64 amount_a = 1 [jstype = JS_STRING];
@@ -109,20 +113,22 @@ message remove_liquidity_result {
 // @read-only false
 // @result empty_object
 message swap_tokens_in_arguments {
-  uint64 amount_in = 1 [jstype = JS_STRING];
-  uint64 amount_out_min = 2 [jstype = JS_STRING];
-  repeated string path = 3;
-  bytes receiver = 4 [(koinos.btype) = ADDRESS];
+  bytes from = 1 [(koinos.btype) = ADDRESS];
+  bytes receiver = 2 [(koinos.btype) = ADDRESS];
+  uint64 amount_in = 3 [jstype = JS_STRING];
+  uint64 amount_out_min = 4 [jstype = JS_STRING];
+  repeated string path = 5;
 }
 
 // @description Swap tokens with exact output
 // @read-only false
 // @result empty_object
 message swap_tokens_out_arguments {
-  uint64 amount_out = 1 [jstype = JS_STRING];
-  uint64 amount_in_max = 2 [jstype = JS_STRING];
-  repeated string path = 3;
-  bytes receiver = 4 [(koinos.btype) = ADDRESS];
+  bytes from = 1 [(koinos.btype) = ADDRESS];
+  bytes receiver = 2 [(koinos.btype) = ADDRESS];
+  uint64 amount_out = 3 [jstype = JS_STRING];
+  uint64 amount_in_max = 4 [jstype = JS_STRING];
+  repeated string path = 5;
 }
 
 // @description Get quote depending on reservations
@@ -155,3 +161,8 @@ message get_amount_in_arguments {
 /*
 * Events
 */
+message register_event {
+  bytes pair = 1 [(koinos.btype) = ADDRESS];
+  string token_a = 2;
+  string token_b = 3;
+}

--- a/assembly/proto/v2core.proto
+++ b/assembly/proto/v2core.proto
@@ -24,21 +24,28 @@ message info {
   string symbol = 2;
   uint32 decimals = 3;
 }
+message token_object {
+  bool is_nameservice = 1;
+  string nameservice = 2;
+  bytes token_address = 3 [(koinos.btype) = ADDRESS];
+}
 message config_object {  
-  bytes token_a = 2 [(koinos.btype) = ADDRESS];
-  bytes token_b = 3 [(koinos.btype) = ADDRESS];
-  string k_last = 4;
-  uint64 reserve_a = 5 [jstype = JS_STRING];
-  uint64 reserve_b = 6 [jstype = JS_STRING];
-  uint64 block_time = 7 [jstype = JS_STRING];
+  bool initialized = 1;
+  bytes periphery = 2 [(koinos.btype) = ADDRESS];
+  token_object token_a = 3;
+  token_object token_b = 4;
+  string k_last = 5;
+  uint64 reserve_a = 6 [jstype = JS_STRING];
+  uint64 reserve_b = 7 [jstype = JS_STRING];
+  uint64 block_time = 8 [jstype = JS_STRING];
 }
 
 /*
 * RPC calls
 */
 message initialize_arguments {
-  bytes token_a = 1 [(koinos.btype) = ADDRESS];
-  bytes token_b = 2 [(koinos.btype) = ADDRESS];
+  token_object token_a = 1;
+  token_object token_b = 2;
 }
 message mint_arguments {
   bytes to = 1 [(koinos.btype) = ADDRESS];


### PR DESCRIPTION
Added the ability to use koinos nameservices to avoid problems when KOIN or VHP addresses are changed due to governance updates.